### PR TITLE
Build login service instance on first request to avoid extension activation errors

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,23 +1,26 @@
-import * as vscode from 'vscode';
-import { RedHatAuthenticationService, onDidChangeSessions } from './authentication-service';
-import { getAuthConfig } from './common/configuration';
 import { getRedHatService, TelemetryService } from "@redhat-developer/vscode-redhat-telemetry";
+import * as vscode from 'vscode';
+import { onDidChangeSessions, RedHatAuthenticationService } from './authentication-service';
+import { getAuthConfig } from './common/configuration';
 
 
 export async function activate(context: vscode.ExtensionContext) {
 	const config = await getAuthConfig();
 
-	const loginService = await RedHatAuthenticationService.build(context, config);
+	let loginService:RedHatAuthenticationService;
 	const telemetryService: TelemetryService = await (await getRedHatService(context)).getTelemetryService();
-
-	context.subscriptions.push(loginService);
-
-	await loginService.initialize();
 
 	context.subscriptions.push(vscode.authentication.registerAuthenticationProvider(config.serviceId,
 		'Red Hat', {
 		onDidChangeSessions: onDidChangeSessions.event,
-		getSessions: (scopes: string[]) => loginService.getSessions(scopes),
+		getSessions: async (scopes: string[]) => {
+			if (!loginService) {
+				loginService = await RedHatAuthenticationService.build(context, config);
+				context.subscriptions.push(loginService);
+				await loginService.initialize();
+			}
+			return loginService.getSessions(scopes);
+		},
 		createSession: async (scopes: string[]) => {
 			try {
 				const session = await loginService.createSession(scopes.sort().join(' '));


### PR DESCRIPTION
Fix #22.

Signed-off-by: Denis Golovin dgolovin@redhat.com
