### PR TITLE
TS2322: Type 'number' is not assignable to type 'Timer'.

### DIFF
--- a/src/authentication-server.ts
+++ b/src/authentication-server.ts
@@ -56,7 +56,7 @@ export function createServer(config:AuthConfig, nonce: string) {
 }
 
 export async function startServer(config:ServerConfig, server: http.Server): Promise<string> {
-	let portTimer: NodeJS.Timer;
+	let portTimer: ReturnType<typeof setTimeout>;
 
 	function cancelPortTimer() {
 		clearTimeout(portTimer);

--- a/src/authentication-service.ts
+++ b/src/authentication-service.ts
@@ -60,7 +60,7 @@ export interface RedHatAuthenticationSession extends vscode.AuthenticationSessio
 export class RedHatAuthenticationService {
 
 	private _tokens: IToken[] = [];
-	private _refreshTimeouts: Map<string, NodeJS.Timeout> = new Map<string, NodeJS.Timeout>();
+	private _refreshTimeouts: Map<string, ReturnType<typeof setTimeout>> = new Map<string, ReturnType<typeof setTimeout>>();
 	//private _uriHandler: UriEventHandler;
 	private _disposables: vscode.Disposable[] = [];
 	private client: Client;


### PR DESCRIPTION
Depending on the context (browser or Node), `setTimeout` returns a
different type.

Here we ruse the `ReturnType` of `setTimeout` instead of `NodeJS.Timeout`.

See: https://nodejs.org/api/timers.html#timers_settimeout_callback_delay_args
See: https://developer.mozilla.org/en-US/docs/Web/API/setTimeout
